### PR TITLE
Remove auto restart code

### DIFF
--- a/C2GUILauncher/src/ViewModels/InstallerViewModel.cs
+++ b/C2GUILauncher/src/ViewModels/InstallerViewModel.cs
@@ -1,6 +1,7 @@
 ﻿//using System.Windows.Shapes;
 using C2GUILauncher.JsonModels;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -24,13 +25,24 @@ namespace C2GUILauncher.ViewModels {
             bool specific = installType != InstallationType.NotSet;
             string exeName = Process.GetCurrentProcess().ProcessName;
             if (exeName != "Chivalry2Launcher") {
+                var messageLines = new List<string>() {
+                    "Set Unchained Modloader as Default?",
+                    "",
+                    "Would you like to set the Unchained Modloader as your default launcher for Chivalry 2? This allows you to easily choose between vanilla Chivalry 2 and the modded Unchained version upon startup.",
+                    "",
+                    "Your original Chivalry 2 launcher will still be accessible and will be renamed to 'Chivalry2Launcher-ORIGINAL.exe'.",
+                    "",
+                    "Yes (Simple) - Replace Chivalry2Launcher.exe with the Unchained Launcher",
+                    "",
+                    "No (Advanced) - Move the Unchained Launcher in to the Chivalry 2 Directory, but Keep Chivalry2Launcher.exe as the default launcher.",
+                    "",
+                    "Cancel - Do not install the Unchained Launcher."
+                };
+
                 MessageBoxResult dialogResult = MessageBox.Show(
-                   $"This program is not currently running in place of the default Chivalry 2 launcher.\n\n" +
-                   $"Do you want this launcher to move itself in place of the Chivalry 2 launcher? The " +
-                   $"default launcher will remain as 'Chivalry2Launcher-ORIGINAL.exe'\n\n" +
-                   $"This will make the launcher start automatically when you launch via Epic Games or " +
-                   $"Steam.\n\nDoing this is required if you are playing on Epic!",
-                   "Replace launcher?", MessageBoxButton.YesNoCancel);
+                    messageLines.Aggregate((a, b) => a + "\n" + b),
+                    "Replace Current Launcher?", MessageBoxButton.YesNoCancel
+                );
 
                 if (dialogResult == MessageBoxResult.Yes ||
                         dialogResult == MessageBoxResult.No) {

--- a/C2GUILauncher/src/ViewModels/InstallerViewModel.cs
+++ b/C2GUILauncher/src/ViewModels/InstallerViewModel.cs
@@ -55,16 +55,12 @@ namespace C2GUILauncher.ViewModels {
                             $"Wait-Process -Id {Environment.ProcessId}; " +
                             $"Start-Sleep -Milliseconds 500; " +
                             $"Move-Item -Force \\\"{originalLauncherPath}\\\" \\\"{originalLauncherDir}\\Chivalry2Launcher-ORIGINAL.exe\\\"; " +
-                            $"Move-Item -Force \\\"{exeName}.exe\\\" \\\"{originalLauncherDir}\\Chivalry2Launcher.exe\\\"; " +
-                            $"Start-Sleep -Milliseconds 500; " +
-                            $"Start-Process \\\"{originalLauncherDir}\\Chivalry2Launcher.exe\\\" -WorkingDirectory \\\"{originalLauncherDir}\\\" {commandLinePass}";
+                            $"Move-Item -Force \\\"{exeName}.exe\\\" \\\"{originalLauncherDir}\\Chivalry2Launcher.exe\\\"; ";
                     } else {
                         powershellCommand =
                             $"Wait-Process -Id {Environment.ProcessId}; " +
                             $"Start-Sleep -Milliseconds 500; " +
-                            $"Move-Item -Force \\\"{exeName}.exe\\\" \\\"{originalLauncherDir}\\{exeName}.exe\\\"; " +
-                            $"Start-Sleep -Milliseconds 500; " +
-                            $"Start-Process \\\"{originalLauncherDir}\\{exeName}.exe\\\" -WorkingDirectory \\\"{originalLauncherDir}\\\" {commandLinePass}";
+                            $"Move-Item -Force \\\"{exeName}.exe\\\" \\\"{originalLauncherDir}\\{exeName}.exe\\\"; ";
                     }
                     //MessageBox.Show(powershellCommand);
                     pwsh.StartInfo.Arguments = $"-Command \"{powershellCommand}\"";

--- a/C2GUILauncher/src/ViewModels/LauncherViewModel.cs
+++ b/C2GUILauncher/src/ViewModels/LauncherViewModel.cs
@@ -26,9 +26,9 @@ namespace C2GUILauncher.ViewModels {
 
         private bool CLIArgsModified { get; set; }
 
+        private Window Window;
 
-
-        public LauncherViewModel(SettingsViewModel settings, ModManager modManager) {
+        public LauncherViewModel(Window window, SettingsViewModel settings, ModManager modManager) {
             CanClick = true;
 
             this.Settings = settings;
@@ -36,6 +36,7 @@ namespace C2GUILauncher.ViewModels {
 
             this.LaunchVanillaCommand = new RelayCommand(LaunchVanilla);
             this.LaunchModdedCommand = new RelayCommand(LaunchModded);
+            this.Window = window;
         }
 
         private void LaunchVanilla() {
@@ -45,6 +46,7 @@ namespace C2GUILauncher.ViewModels {
                 var args = string.Join(" ", Environment.GetCommandLineArgs().Skip(1));
                 Chivalry2Launchers.VanillaLauncher.Launch(args);
                 CanClick = false;
+                Window.Close();
             } catch (Exception ex) {
                 MessageBox.Show(ex.ToString());
             }
@@ -75,8 +77,17 @@ namespace C2GUILauncher.ViewModels {
                     Chivalry2Launchers.ModdedLauncher.Dlls = dlls;
                     var process = Chivalry2Launchers.ModdedLauncher.Launch(args);
 
+
+                    await Window.Dispatcher.BeginInvoke((Action)delegate () {
+                        Window.Hide();
+                    });
+
                     await process.WaitForExitAsync();
-                    Environment.Exit(0);
+
+                    await Window.Dispatcher.BeginInvoke((Action)delegate () {
+                        Window.Close();
+                    });
+
                 } catch (Exception ex) {
                     MessageBox.Show(ex.ToString());
                 }
@@ -84,6 +95,7 @@ namespace C2GUILauncher.ViewModels {
 
             launchThread.Start();
             CanClick = false;
+            Window.Hide();
         }
 
         private InstallationType GetInstallationType() {

--- a/C2GUILauncher/src/Views/MainWindow.xaml.cs
+++ b/C2GUILauncher/src/Views/MainWindow.xaml.cs
@@ -101,7 +101,7 @@ namespace C2GUILauncher {
                         MessageBox.Show($"Installation rejected. Running launcher in-place.");
                         break;
                     case InstallResult.Installed:
-                        MessageBox.Show($"Launcher installation is complete.");
+                        MessageBox.Show($"Launcher installation is complete. Launch Chivalry2 Normally via EGS or Steam.");
                         this.Close();
                         break;
                     case InstallResult.Failed:

--- a/C2GUILauncher/src/Views/MainWindow.xaml.cs
+++ b/C2GUILauncher/src/Views/MainWindow.xaml.cs
@@ -130,7 +130,7 @@ namespace C2GUILauncher {
                     this.SettingsViewModel.InstallationType = InstallationType.Steam;
             }
             this.ModManagerViewModel = new ModListViewModel(ModManager);
-            this.LauncherViewModel = new LauncherViewModel(SettingsViewModel, ModManager);
+            this.LauncherViewModel = new LauncherViewModel(this, SettingsViewModel, ModManager);
 
             this.SettingsTab.DataContext = this.SettingsViewModel;
             this.ModManagerTab.DataContext = this.ModManagerViewModel;


### PR DESCRIPTION
Currently the launcher restarts automatically after installing itself, but that's only valid in 1 of 4 scenarios.

Steam with mods: Works fine
Steam without mods: No work, because no auth and no eac
EGS with mods: No work because no auth
EGS without mods: No work because no auth and no eac

This change makes it so all users would have the same experience, and there won't be any invalid launch scenarios.