### PR TITLE
Servers

### DIFF
--- a/C2GUILauncher/src/ViewModels/LauncherViewModel.cs
+++ b/C2GUILauncher/src/ViewModels/LauncherViewModel.cs
@@ -167,6 +167,8 @@ namespace C2GUILauncher.ViewModels {
                 int TBLloc = cliArgs.IndexOf("TBL");
                 cliArgs.Insert(TBLloc, RCONMap);
                 cliArgs.Add("-nullrhi"); //disable rendering
+                //this isn't used, but will be needed later
+                cliArgs.Add("-rcon 9001"); //let the serverplugin know that we want RCON running on the given port
                 cliArgs.Add("-RenderOffScreen"); //*really* disable rendering
                 cliArgs.Add("-unattended"); //let it know no one's around to help
                 cliArgs.Add("-nosound"); //disable sound

--- a/C2GUILauncher/src/ViewModels/LauncherViewModel.cs
+++ b/C2GUILauncher/src/ViewModels/LauncherViewModel.cs
@@ -115,6 +115,8 @@ namespace C2GUILauncher.ViewModels {
             Process serverRegister = new Process();
             //We *must* use cmd.exe as a wrapper to start RegisterUnchainedServer.exe, otherwise we have no way to
             //close the window later
+
+            //TODO: Get this to actually be able to be closed
             serverRegister.StartInfo.FileName = "cmd.exe";
             
             string registerCommand = $"RegisterUnchainedServer.exe " +
@@ -123,6 +125,7 @@ namespace C2GUILauncher.ViewModels {
                 $"-r ^\"{ServerSettings.serverList}^\" " +
                 $"-c ^\"{ServerSettings.rconPort}^\"";
             serverRegister.StartInfo.Arguments = $"/c \"{registerCommand}\"";
+            serverRegister.StartInfo.CreateNoWindow = false;
             //MessageBox.Show($"{serverRegister.StartInfo.Arguments}");
 
             return serverRegister;

--- a/C2GUILauncher/src/ViewModels/ServerSettingsViewModel.cs
+++ b/C2GUILauncher/src/ViewModels/ServerSettingsViewModel.cs
@@ -1,0 +1,23 @@
+﻿using PropertyChanged;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Windows;
+
+namespace C2GUILauncher.src.ViewModels {
+    [AddINotifyPropertyChangedInterface]
+    public class ServerSettingsViewModel {
+        public string serverName { get; set; } = "Chivalry 2 server";
+        public string serverDescription { get; set; } = "Example description";
+        public string serverList { get; set; } = "https://servers.polehammer.net";
+        public int gamePort { get; set; } = 7777;
+        public int rconPort { get; set; } = 9001;
+        public int a2sPort { get; set; } = 7071;
+        public int pingPort { get; set; } = 3075;
+
+        //may want to add a mods list here as well,
+        //in the hopes of having multiple independent servers running one one machine
+        //whose settings can be stored/loaded from files
+    }
+}

--- a/C2GUILauncher/src/ViewModels/SettingsViewModel.cs
+++ b/C2GUILauncher/src/ViewModels/SettingsViewModel.cs
@@ -131,6 +131,7 @@ namespace C2GUILauncher.ViewModels {
                         $".\\Chivalry2Launcher.exe {commandLinePass}";
                         pwsh.StartInfo.Arguments = $"-Command \"{powershellCommand}\"";
                         pwsh.StartInfo.CreateNoWindow = true;
+                        
                         pwsh.Start();
                         MessageBox.Show("The launcher will now close and start the new version. No further action must be taken.");
                         window?.Close(); //close the program

--- a/C2GUILauncher/src/Views/MainWindow.xaml
+++ b/C2GUILauncher/src/Views/MainWindow.xaml
@@ -1,7 +1,11 @@
 ﻿<Window
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:av="http://schemas.microsoft.com/expression/blend/2008" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" x:Name="Unchained_Launcher" mc:Ignorable="av" x:Class="C2GUILauncher.MainWindow"
+        xmlns:av="http://schemas.microsoft.com/expression/blend/2008" 
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+        x:Name="Unchained_Launcher" 
+        mc:Ignorable="av" 
+        x:Class="C2GUILauncher.MainWindow"   
         Title="Unchained Launcher" Height="250" Width="600"
     >
 
@@ -145,6 +149,44 @@
                 <TextBox Text="{Binding CLIArgs}" Grid.Row="5" Grid.ColumnSpan ="2" TextWrapping="Wrap" IsManipulationEnabled="True" AcceptsReturn="True" />
                 <Button Content="Check for updates" Grid.Row="6" Grid.Column="0" Margin="5" Command="{Binding CheckForUpdateCommand}" />
                 <TextBlock Text="{Binding CurrentVersion}" Grid.Row="6" Grid.ColumnSpan ="2" Grid.Column="1" HorizontalAlignment="Center" Height="NaN" Margin="0,0,0,0" VerticalAlignment="Center" Width="NaN" />
+            </Grid>
+        </TabItem>
+
+        <TabItem x:Name="ServerSettingsTab"  DataContext="{Binding ServerSettingsViewModel}" Header="Server">
+            <Grid HorizontalAlignment="Stretch" Margin="0,0,0,0" Width="NaN" VerticalAlignment="Stretch">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="*"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+
+                <TextBlock Text="Server List:" Grid.Row="0" Grid.Column ="2" Grid.ColumnSpan ="2" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="5"/>
+                <TextBlock Text="Server Name:" Grid.Row="0" Grid.ColumnSpan ="2" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="5"/>
+                <TextBox Text="{Binding serverList}" Grid.Row="1" Grid.Column ="2" Grid.ColumnSpan ="2" Margin ="5,0,5,0" TextWrapping="Wrap" IsManipulationEnabled="True" AcceptsReturn="False" />
+                <TextBox Text="{Binding serverName}" Grid.Row="1" Grid.ColumnSpan ="2" TextWrapping="Wrap" Margin ="5,0,5,0" IsManipulationEnabled="True" AcceptsReturn="False" />
+                <TextBlock Text="Server Description:" Grid.Row="2" Grid.ColumnSpan ="4" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="5"/>
+                <TextBox Text="{Binding serverDescription}" Grid.Row="3" Grid.ColumnSpan ="4" TextWrapping="Wrap" IsManipulationEnabled="True" AcceptsReturn="True" />
+                <Rectangle Fill="Gray" IsHitTestVisible="False" Grid.Row="5" Grid.Column="2" Grid.ColumnSpan ="2"/>
+                <Rectangle Fill="Gray" IsHitTestVisible="False" Grid.Row="4" Grid.Column="2" Grid.ColumnSpan ="2"/>
+                <TextBlock Text="Game port:" Grid.Row="4" Grid.Column = "0" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="5"/>
+                <TextBlock Text="RCON port:" Grid.Row="4" Grid.Column = "1" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="5"/>
+                <TextBlock Text="A2S port:" Grid.Row="4" Grid.Column = "2" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="5"/>
+                <TextBlock Text="Ping port:" Grid.Row="4" Grid.Column = "3" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="5"/>
+                <TextBox Text="{Binding gamePort}" Grid.Row="5" Grid.Column = "0" TextWrapping="Wrap" Margin ="5" IsManipulationEnabled="True" AcceptsReturn="True" />
+                <TextBox Text="{Binding rconPort}" Grid.Row="5" Grid.Column = "1" TextWrapping="Wrap" Margin ="5" IsManipulationEnabled="True" AcceptsReturn="True" />
+                <TextBox Text="{Binding a2sPort}" Grid.Row="5" Grid.Column = "2" TextWrapping="Wrap" Margin ="5" IsManipulationEnabled="True" AcceptsReturn="True" />
+                <TextBox Text="{Binding pingPort}" Grid.Row="5" Grid.Column = "3" TextWrapping="Wrap" Margin ="5" IsManipulationEnabled="True" AcceptsReturn="True" />
+                
             </Grid>
         </TabItem>
     </TabControl>

--- a/C2GUILauncher/src/Views/MainWindow.xaml
+++ b/C2GUILauncher/src/Views/MainWindow.xaml
@@ -33,6 +33,7 @@
                 <Grid.RowDefinitions>
                     <RowDefinition Height="*"/>
                     <RowDefinition Height="*"/>
+                    <RowDefinition Height="*"/>
                 </Grid.RowDefinitions>
 
                 <Grid.ColumnDefinitions>
@@ -41,6 +42,7 @@
 
                 <Button x:Name="LaunchVanillaButton" Content="Launch Vanilla" Grid.Row="0" Command="{Binding LaunchVanillaCommand}" />
                 <Button x:Name="LaunchModdedButton" Content="Launch With Mods" Grid.Row="1" Command="{Binding LaunchModdedCommand}" />
+                <Button x:Name="LaunchServerButton" Content="Launch Headless Server" Grid.Row="2" Command="{Binding LaunchServerCommand}" />
             </Grid>
         </TabItem>
         <TabItem x:Name="ModManagerTab"  DataContext="{Binding ModManagerViewModel}"  Header="Mod Manager">

--- a/C2GUILauncher/src/Views/MainWindow.xaml
+++ b/C2GUILauncher/src/Views/MainWindow.xaml
@@ -38,11 +38,13 @@
 
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="*"/>
                 </Grid.ColumnDefinitions>
 
-                <Button x:Name="LaunchVanillaButton" Content="Launch Vanilla" Grid.Row="0" Command="{Binding LaunchVanillaCommand}" />
-                <Button x:Name="LaunchModdedButton" Content="Launch With Mods" Grid.Row="1" Command="{Binding LaunchModdedCommand}" />
-                <Button x:Name="LaunchServerButton" Content="Launch Headless Server" Grid.Row="2" Command="{Binding LaunchServerCommand}" />
+                <Button x:Name="LaunchVanillaButton" Content="Launch Vanilla" Grid.Row="0" Grid.ColumnSpan = "2" Command="{Binding LaunchVanillaCommand}" />
+                <Button x:Name="LaunchModdedButton" Content="Launch With Mods" Grid.Row="1" Grid.ColumnSpan = "2" Command="{Binding LaunchModdedCommand}" />
+                <Button x:Name="LaunchServerButton" Content="Launch Server" Grid.Row="2" Grid.Column="0" Command="{Binding LaunchServerCommand}" />
+                <Button x:Name="LaunchServerHeadlessButton" Content="Launch Headless Server" Grid.Row="2" Grid.Column="1" Command="{Binding LaunchServerHeadlessCommand}" />
             </Grid>
         </TabItem>
         <TabItem x:Name="ModManagerTab"  DataContext="{Binding ModManagerViewModel}"  Header="Mod Manager">

--- a/C2GUILauncher/src/Views/MainWindow.xaml.cs
+++ b/C2GUILauncher/src/Views/MainWindow.xaml.cs
@@ -15,6 +15,7 @@ namespace C2GUILauncher {
         public ModListViewModel ModManagerViewModel { get; }
         public SettingsViewModel SettingsViewModel { get; }
         public LauncherViewModel LauncherViewModel { get; }
+        public ServerSettingsViewModel ServerSettingsViewModel { get; }
 
         private readonly ModManager ModManager;
 
@@ -34,11 +35,13 @@ namespace C2GUILauncher {
 
             this.SettingsViewModel = SettingsViewModel.LoadSettings();
             this.ModManagerViewModel = new ModListViewModel(ModManager);
-            this.LauncherViewModel = new LauncherViewModel(SettingsViewModel, ModManager);
+            this.ServerSettingsViewModel = new ServerSettingsViewModel();
+            this.LauncherViewModel = new LauncherViewModel(SettingsViewModel, this.ServerSettingsViewModel, ModManager);
 
             this.SettingsTab.DataContext = this.SettingsViewModel;
             this.ModManagerTab.DataContext = this.ModManagerViewModel;
             this.LauncherTab.DataContext = this.LauncherViewModel;
+            this.ServerSettingsTab.DataContext = this.ServerSettingsViewModel;
 
             this.Closed += MainWindow_Closed;
         }


### PR DESCRIPTION
Adds two launch buttons to main menu for launching servers (headless and headful). These automatically launch the server registration python client. Headless launch also automatically sets the cli to activate the RCON zombie in-game for connectivity.

Adds a server settings page for configuring launched servers. These settings are passed to the server registration python client when it is launched